### PR TITLE
# feat(clarity): add Civitas DAO treasury contract with proposals, voting, and execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,108 @@
+# Civitas DAO (contracts/civitas.clar)
+
+A minimal DAO treasury in Clarity. Contributors deposit STX into the contract, propose spending, vote, and execute approved proposals.
+
+## Constants
+- MIN_VOTE_THRESHOLD: u2
+- PROPOSAL_LIFETIME: u100 blocks
+- MIN_CONTRIBUTION: u1000000 (1 STX)
+- MAX_PROPOSAL_AMOUNT: u1000000000000 (1,000,000 STX)
+- MAX_PROPOSAL_ID: u4294967295
+
+## Errors (defined)
+- ERR_NOT_CONTRIBUTOR u300
+- ERR_ALREADY_VOTED u101
+- ERR_PROPOSAL_NOT_FOUND u102
+- ERR_PROPOSAL_EXECUTED u100
+- ERR_PROPOSAL_EXPIRED u104
+- ERR_INSUFFICIENT_VOTES u201
+- ERR_INSUFFICIENT_BALANCE u202
+- ERR_PROPOSAL_ALREADY_EXECUTED u200
+- ERR_PROPOSAL_EXPIRED_EXEC u204
+- ERR_PROPOSAL_NOT_FOUND_EXEC u203
+- ERR_INVALID_AMOUNT u400
+- ERR_INVALID_PROPOSAL_ID u401
+- ERR_INVALID_RECIPIENT u402
+
+## State
+- Data var:
+  - next-proposal-id: uint (starts at u0)
+- Maps:
+  - contributors: principal -> { contributed: bool, amount: uint }
+  - proposals: uint -> {
+      amount: uint,
+      recipient: principal,
+      description: (string-ascii 100),
+      yes-votes: uint,
+      no-votes: uint,
+      executed: bool,
+      start-block: uint,
+      proposer: principal
+    }
+  - votes: { proposal-id: uint, voter: principal } -> { voted: bool, support: bool }
+
+## Core rules
+- Becoming a contributor requires calling contribute with amount >= MIN_CONTRIBUTION.
+- Proposal IDs are sequential starting at u0.
+- A proposal is active if not executed and not expired. Expiry condition: (stacks-block-height - start-block) > PROPOSAL_LIFETIME.
+- One principal = one vote per proposal; votes are not weighted by contribution.
+- Execution requires yes-votes >= MIN_VOTE_THRESHOLD; no-votes are tracked but do not affect the threshold check.
+
+## Public functions
+
+- contribute(amount uint) -> (response uint uint)
+  - Transfers amount from tx-sender to the contract and upserts contributors[tx-sender].
+  - Requires: amount >= MIN_CONTRIBUTION and amount <= MAX_PROPOSAL_AMOUNT.
+  - Ok: amount
+  - Err: ERR_INVALID_AMOUNT; or propagates stx-transfer? error.
+
+- propose-spend(amount uint, recipient principal, description (string-ascii 100)) -> (response uint uint)
+  - Requires caller is a contributor.
+  - Stores a new proposal with the current next-proposal-id and increments it.
+  - Requires: amount > u0 and <= MAX_PROPOSAL_AMOUNT; recipient != contract principal; next-proposal-id < MAX_PROPOSAL_ID.
+  - Ok: proposal-id
+  - Err: ERR_INVALID_AMOUNT, ERR_INVALID_RECIPIENT, ERR_NOT_CONTRIBUTOR, ERR_INVALID_PROPOSAL_ID
+
+- vote(proposal-id uint, support bool) -> (response bool uint)
+  - Records a vote and increments yes-votes or no-votes.
+  - Requires: valid proposal-id; caller is a contributor; proposal is active; caller has not voted on this proposal.
+  - Ok: true
+  - Err: ERR_INVALID_PROPOSAL_ID, ERR_NOT_CONTRIBUTOR, ERR_PROPOSAL_EXPIRED, ERR_ALREADY_VOTED, ERR_PROPOSAL_NOT_FOUND
+
+- execute-proposal(proposal-id uint) -> (response bool uint)
+  - Executes an STX transfer from the contract to the proposal recipient.
+  - Requires: valid proposal-id; proposal exists; not executed; not expired; yes-votes >= MIN_VOTE_THRESHOLD; contract balance >= amount; stored amount/recipient still valid.
+  - Ok: true
+  - Err: ERR_INVALID_PROPOSAL_ID, ERR_PROPOSAL_ALREADY_EXECUTED, ERR_PROPOSAL_EXPIRED_EXEC, ERR_INSUFFICIENT_VOTES, ERR_INSUFFICIENT_BALANCE, ERR_INVALID_AMOUNT, ERR_INVALID_RECIPIENT, ERR_PROPOSAL_NOT_FOUND_EXEC; or propagates stx-transfer? error.
+
+## Read-only functions
+
+- get-proposal(proposal-id uint) -> (response {…proposal…} uint)
+  - Requires valid proposal-id.
+  - Err: ERR_INVALID_PROPOSAL_ID, ERR_PROPOSAL_NOT_FOUND
+
+- get-balance() -> uint
+  - Returns the contract’s STX balance.
+
+- is-user-contributor(user principal) -> (response bool none)
+  - Ok true if user exists in contributors with contributed = true; otherwise Ok false.
+
+- get-contributor(user principal) -> (optional { contributed: bool, amount: uint })
+
+- get-vote(proposal-id uint, voter principal) -> (response (optional { voted: bool, support: bool }) uint)
+  - Requires valid proposal-id.
+  - Err: ERR_INVALID_PROPOSAL_ID
+
+- get-next-proposal-id() -> uint
+
+- is-proposal-active-check(proposal-id uint) -> (response bool uint)
+  - Requires valid proposal-id.
+  - Ok true if active by the same logic used for voting.
+  - Err: ERR_INVALID_PROPOSAL_ID, ERR_PROPOSAL_NOT_FOUND
+
+## Validation helpers (private)
+- validate-proposal-id(proposal-id) -> bool: proposal-id <= MAX_PROPOSAL_ID and proposal-id < next-proposal-id.
+- validate-amount(amount) -> bool: amount > u0 and amount <= MAX_PROPOSAL_AMOUNT.
+- validate-recipient(recipient) -> bool: recipient != contract principal.
+- is-contributor(user) -> (response bool uint): Ok(contributed) if present; Err(ERR_NOT_CONTRIBUTOR) if absent.
+- is-proposal-active(proposal-data) -> bool: not executed and not expired by the lifetime rule.

--- a/contracts/civitas.clar
+++ b/contracts/civitas.clar
@@ -1,0 +1,301 @@
+;; Civitas DAO - A decentralized autonomous organization for treasury management
+;; Contributors can propose spending and vote on proposals
+
+;; =============================================================================
+;; CONSTANTS & ERRORS
+;; =============================================================================
+
+(define-constant MIN_VOTE_THRESHOLD u2)
+(define-constant PROPOSAL_LIFETIME u100) ;; blocks
+(define-constant MIN_CONTRIBUTION u1000000) ;; 1 STX minimum contribution
+(define-constant MAX_PROPOSAL_AMOUNT u1000000000000) ;; 1M STX max proposal
+(define-constant MAX_PROPOSAL_ID u4294967295) ;; Max uint32
+
+;; Error codes
+(define-constant ERR_NOT_CONTRIBUTOR u300)
+(define-constant ERR_ALREADY_VOTED u101)
+(define-constant ERR_PROPOSAL_NOT_FOUND u102)
+(define-constant ERR_PROPOSAL_EXECUTED u100)
+(define-constant ERR_PROPOSAL_EXPIRED u104)
+(define-constant ERR_INSUFFICIENT_VOTES u201)
+(define-constant ERR_INSUFFICIENT_BALANCE u202)
+(define-constant ERR_PROPOSAL_ALREADY_EXECUTED u200)
+(define-constant ERR_PROPOSAL_EXPIRED_EXEC u204)
+(define-constant ERR_PROPOSAL_NOT_FOUND_EXEC u203)
+(define-constant ERR_INVALID_AMOUNT u400)
+(define-constant ERR_INVALID_PROPOSAL_ID u401)
+(define-constant ERR_INVALID_RECIPIENT u402)
+
+;; =============================================================================
+;; DATA VARIABLES
+;; =============================================================================
+
+(define-data-var next-proposal-id uint u0)
+
+;; =============================================================================
+;; DATA MAPS
+;; =============================================================================
+
+;; Track contributors and their contribution amounts
+(define-map contributors
+  principal
+  {
+    contributed: bool,
+    amount: uint
+  }
+)
+
+;; Store proposal details
+(define-map proposals
+  uint
+  {
+    amount: uint,
+    recipient: principal,
+    description: (string-ascii 100),
+    yes-votes: uint,
+    no-votes: uint,
+    executed: bool,
+    start-block: uint,
+    proposer: principal
+  }
+)
+
+;; Track votes to prevent double voting
+(define-map votes
+  {proposal-id: uint, voter: principal}
+  {voted: bool, support: bool}
+)
+
+;; =============================================================================
+;; PRIVATE FUNCTIONS
+;; =============================================================================
+
+;; Validate proposal ID input
+(define-private (validate-proposal-id (proposal-id uint))
+  (and 
+    (<= proposal-id MAX_PROPOSAL_ID)
+    (< proposal-id (var-get next-proposal-id))
+  )
+)
+
+;; Validate amount input
+(define-private (validate-amount (amount uint))
+  (and 
+    (> amount u0)
+    (<= amount MAX_PROPOSAL_AMOUNT)
+  )
+)
+
+;; Validate recipient address (ensure it's not the contract itself)
+(define-private (validate-recipient (recipient principal))
+  (not (is-eq recipient (as-contract tx-sender)))
+)
+
+;; Check if a user is a contributor
+(define-private (is-contributor (user principal))
+  (match (map-get? contributors user)
+    contributor-data (ok (get contributed contributor-data))
+    (err ERR_NOT_CONTRIBUTOR)
+  )
+)
+
+;; Check if proposal is still active (not expired and not executed)
+(define-private (is-proposal-active (proposal-data {amount: uint, recipient: principal, description: (string-ascii 100), yes-votes: uint, no-votes: uint, executed: bool, start-block: uint, proposer: principal}))
+  (let (
+    (executed (get executed proposal-data))
+    (start (get start-block proposal-data))
+    (expired (> (- stacks-block-height start) PROPOSAL_LIFETIME))
+  )
+    (and (not executed) (not expired))
+  )
+)
+
+;; =============================================================================
+;; PUBLIC FUNCTIONS
+;; =============================================================================
+
+;; Contribute STX to the treasury with a specified amount
+(define-public (contribute (amount uint))
+  (begin
+    ;; Validate input amount
+    (asserts! (>= amount MIN_CONTRIBUTION) (err ERR_INVALID_AMOUNT))
+    (asserts! (<= amount MAX_PROPOSAL_AMOUNT) (err ERR_INVALID_AMOUNT))
+    
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (match (map-get? contributors tx-sender)
+      existing-contributor
+      ;; Update existing contributor
+      (map-set contributors tx-sender {
+        contributed: true,
+        amount: (+ (get amount existing-contributor) amount)
+      })
+      ;; New contributor
+      (map-set contributors tx-sender {
+        contributed: true,
+        amount: amount
+      })
+    )
+    (ok amount)
+  )
+)
+
+;; Propose a spend from the treasury
+(define-public (propose-spend (amount uint) (recipient principal) (description (string-ascii 100)))
+  (begin
+    ;; Validate all inputs
+    (asserts! (validate-amount amount) (err ERR_INVALID_AMOUNT))
+    (asserts! (validate-recipient recipient) (err ERR_INVALID_RECIPIENT))
+    (try! (is-contributor tx-sender))
+    
+    (let ((proposal-id (var-get next-proposal-id)))
+      ;; Ensure we don't overflow proposal IDs
+      (asserts! (< proposal-id MAX_PROPOSAL_ID) (err ERR_INVALID_PROPOSAL_ID))
+      
+      (map-set proposals proposal-id {
+        amount: amount,
+        recipient: recipient,
+        description: description,
+        yes-votes: u0,
+        no-votes: u0,
+        executed: false,
+        start-block: stacks-block-height,
+        proposer: tx-sender
+      })
+      (var-set next-proposal-id (+ proposal-id u1))
+      (ok proposal-id)
+    )
+  )
+)
+
+;; Vote on a proposal
+(define-public (vote (proposal-id uint) (support bool))
+  (begin
+    ;; Validate inputs
+    (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
+    (try! (is-contributor tx-sender))
+    
+    (match (map-get? proposals proposal-id)
+      proposal-data
+      (let (
+        (vote-key {proposal-id: proposal-id, voter: tx-sender})
+      )
+        (asserts! (is-proposal-active proposal-data) (err ERR_PROPOSAL_EXPIRED))
+        (asserts! (is-none (map-get? votes vote-key)) (err ERR_ALREADY_VOTED))
+        
+        ;; Record the vote
+        (map-set votes vote-key {voted: true, support: support})
+        
+        ;; Update proposal vote counts
+        (if support
+          (map-set proposals proposal-id (merge proposal-data {
+            yes-votes: (+ (get yes-votes proposal-data) u1)
+          }))
+          (map-set proposals proposal-id (merge proposal-data {
+            no-votes: (+ (get no-votes proposal-data) u1)
+          }))
+        )
+        (ok true)
+      )
+      (err ERR_PROPOSAL_NOT_FOUND)
+    )
+  )
+)
+
+;; Execute proposal if it meets threshold and requirements
+(define-public (execute-proposal (proposal-id uint))
+  (begin
+    ;; Validate input
+    (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
+    
+    (match (map-get? proposals proposal-id)
+      proposal-data
+      (let (
+        (executed (get executed proposal-data))
+        (start (get start-block proposal-data))
+        (expired (> (- stacks-block-height start) PROPOSAL_LIFETIME))
+        (yes-votes (get yes-votes proposal-data))
+        (proposal-amount (get amount proposal-data))
+        (proposal-recipient (get recipient proposal-data))
+        (balance (stx-get-balance (as-contract tx-sender)))
+      )
+        ;; Validate proposal state and requirements
+        (asserts! (not executed) (err ERR_PROPOSAL_ALREADY_EXECUTED))
+        (asserts! (not expired) (err ERR_PROPOSAL_EXPIRED_EXEC))
+        (asserts! (>= yes-votes MIN_VOTE_THRESHOLD) (err ERR_INSUFFICIENT_VOTES))
+        (asserts! (>= balance proposal-amount) (err ERR_INSUFFICIENT_BALANCE))
+        
+        ;; Re-validate the stored data before execution
+        (asserts! (validate-amount proposal-amount) (err ERR_INVALID_AMOUNT))
+        (asserts! (validate-recipient proposal-recipient) (err ERR_INVALID_RECIPIENT))
+        
+        ;; Execute the transfer
+        (try! (as-contract (stx-transfer? proposal-amount tx-sender proposal-recipient)))
+        
+        ;; Mark proposal as executed
+        (map-set proposals proposal-id (merge proposal-data {executed: true}))
+        (ok true)
+      )
+      (err ERR_PROPOSAL_NOT_FOUND_EXEC)
+    )
+  )
+)
+
+;; =============================================================================
+;; READ-ONLY FUNCTIONS
+;; =============================================================================
+
+;; Get proposal details
+(define-read-only (get-proposal (proposal-id uint))
+  (begin
+    ;; Validate input
+    (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
+    (match (map-get? proposals proposal-id)
+      proposal-data (ok proposal-data)
+      (err ERR_PROPOSAL_NOT_FOUND)
+    )
+  )
+)
+
+;; Get treasury balance
+(define-read-only (get-balance)
+  (stx-get-balance (as-contract tx-sender))
+)
+
+;; Check if user is a contributor
+(define-read-only (is-user-contributor (user principal))
+  (match (map-get? contributors user)
+    contributor-data (ok (get contributed contributor-data))
+    (ok false)
+  )
+)
+
+;; Get contributor details
+(define-read-only (get-contributor (user principal))
+  (map-get? contributors user)
+)
+
+;; Get vote details for a specific proposal and voter
+(define-read-only (get-vote (proposal-id uint) (voter principal))
+  (begin
+    ;; Validate input
+    (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
+    (ok (map-get? votes {proposal-id: proposal-id, voter: voter}))
+  )
+)
+
+;; Get next proposal ID
+(define-read-only (get-next-proposal-id)
+  (var-get next-proposal-id)
+)
+
+;; Check if proposal is active
+(define-read-only (is-proposal-active-check (proposal-id uint))
+  (begin
+    ;; Validate input
+    (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
+    (match (map-get? proposals proposal-id)
+      proposal-data (ok (is-proposal-active proposal-data))
+      (err ERR_PROPOSAL_NOT_FOUND)
+    )
+  )
+)

--- a/contracts/civitas.clar
+++ b/contracts/civitas.clar
@@ -25,6 +25,7 @@
 (define-constant ERR_INVALID_AMOUNT u400)
 (define-constant ERR_INVALID_PROPOSAL_ID u401)
 (define-constant ERR_INVALID_RECIPIENT u402)
+(define-constant ERR_WEIGHT_AFTER_SNAPSHOT u403)
 
 ;; =============================================================================
 ;; DATA VARIABLES
@@ -42,7 +43,8 @@
   principal
   {
     contributed: bool,
-    amount: uint
+    amount: uint,
+    last-contribution-proposal-id: uint
   }
 )
 
@@ -108,12 +110,12 @@
   (not (is-eq recipient (as-contract tx-sender)))
 )
 
-;; Check if a user is a contributor and return their contribution amount
-(define-private (get-contributor-weight (user principal))
+;; Check if a user is a contributor and return their stored data
+(define-private (get-contributor-data (user principal))
   (match (map-get? contributors user)
     contributor-data 
     (if (get contributed contributor-data)
-      (ok (get amount contributor-data))
+      (ok contributor-data)
       (err ERR_NOT_CONTRIBUTOR)
     )
     (err ERR_NOT_CONTRIBUTOR)
@@ -143,23 +145,30 @@
     (asserts! (<= amount MAX_PROPOSAL_AMOUNT) (err ERR_INVALID_AMOUNT))
     
     (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
-    (match (map-get? contributors tx-sender)
-      existing-contributor
-      ;; Update existing contributor
-      (begin
-        (map-set contributors tx-sender {
-          contributed: true,
-          amount: (+ (get amount existing-contributor) amount)
-        })
-        (var-set total-contributions (+ (var-get total-contributions) amount))
-      )
-      ;; New contributor
-      (begin
-        (map-set contributors tx-sender {
-          contributed: true,
-          amount: amount
-        })
-        (var-set total-contributions (+ (var-get total-contributions) amount))
+    (let ((current-proposal-id (var-get next-proposal-id)))
+      (match (map-get? contributors tx-sender)
+        existing-contributor
+        ;; Update existing contributor
+        (let (
+          (existing-amount (get amount existing-contributor))
+          (new-amount (+ existing-amount amount))
+        )
+          (map-set contributors tx-sender {
+            contributed: true,
+            amount: new-amount,
+            last-contribution-proposal-id: current-proposal-id
+          })
+          (var-set total-contributions (+ (var-get total-contributions) amount))
+        )
+        ;; New contributor
+        (begin
+          (map-set contributors tx-sender {
+            contributed: true,
+            amount: amount,
+            last-contribution-proposal-id: current-proposal-id
+          })
+          (var-set total-contributions (+ (var-get total-contributions) amount))
+        )
       )
     )
     (ok amount)
@@ -172,7 +181,7 @@
     ;; Validate all inputs
     (asserts! (validate-amount amount) (err ERR_INVALID_AMOUNT))
     (asserts! (validate-recipient recipient) (err ERR_INVALID_RECIPIENT))
-    (try! (get-contributor-weight tx-sender))
+    (try! (get-contributor-data tx-sender))
     
     (let ((proposal-id (var-get next-proposal-id))
           (current-total-weight (var-get total-contributions)))
@@ -201,13 +210,15 @@
   (begin
     ;; Validate inputs
     (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
-    (let ((voter-weight (try! (get-contributor-weight tx-sender))))
-      
+    (let ((contributor (try! (get-contributor-data tx-sender))))
       (match (map-get? proposals proposal-id)
         proposal-data
         (let (
           (vote-key {proposal-id: proposal-id, voter: tx-sender})
+          (last-id (get last-contribution-proposal-id contributor))
+          (voter-weight (get amount contributor))
         )
+          (asserts! (<= last-id proposal-id) (err ERR_WEIGHT_AFTER_SNAPSHOT))
           (asserts! (is-proposal-active proposal-data) (err ERR_PROPOSAL_EXPIRED))
           (asserts! (is-none (map-get? votes vote-key)) (err ERR_ALREADY_VOTED))
           
@@ -261,6 +272,35 @@
         
         ;; Execute the transfer
         (try! (as-contract (stx-transfer? proposal-amount tx-sender proposal-recipient)))
+        
+        ;; Reduce recorded voting weight for recipients drawing from the treasury
+        (match (map-get? contributors proposal-recipient)
+          recipient-data
+          (let (
+            (current-amount (get amount recipient-data))
+            (deduction (if (> proposal-amount current-amount) current-amount proposal-amount))
+          )
+            (if (> deduction u0)
+              (let (
+                (current-total (var-get total-contributions))
+                (new-total (if (> current-total deduction) (- current-total deduction) u0))
+                (new-amount (- current-amount deduction))
+                (last-id (get last-contribution-proposal-id recipient-data))
+                (still-contributor (if (> new-amount u0) true false))
+              )
+                (map-set contributors proposal-recipient {
+                  contributed: still-contributor,
+                  amount: new-amount,
+                  last-contribution-proposal-id: last-id
+                })
+                (var-set total-contributions new-total)
+                u0
+              )
+              u0
+            )
+          )
+          u0
+        )
         
         ;; Mark proposal as executed
         (map-set proposals proposal-id (merge proposal-data {executed: true}))

--- a/contracts/civitas.clar
+++ b/contracts/civitas.clar
@@ -1,11 +1,11 @@
 ;; Civitas DAO - A decentralized autonomous organization for treasury management
-;; Contributors can propose spending and vote on proposals
+;; Contributors can propose spending and vote on proposals with weighted voting
 
 ;; =============================================================================
 ;; CONSTANTS & ERRORS
 ;; =============================================================================
 
-(define-constant MIN_VOTE_THRESHOLD u2)
+(define-constant MIN_VOTE_THRESHOLD u51) ;; 51% of total contribution weight needed
 (define-constant PROPOSAL_LIFETIME u100) ;; blocks
 (define-constant MIN_CONTRIBUTION u1000000) ;; 1 STX minimum contribution
 (define-constant MAX_PROPOSAL_AMOUNT u1000000000000) ;; 1M STX max proposal
@@ -31,6 +31,7 @@
 ;; =============================================================================
 
 (define-data-var next-proposal-id uint u0)
+(define-data-var total-contributions uint u0) ;; Track total contributions for weighted voting
 
 ;; =============================================================================
 ;; DATA MAPS
@@ -45,30 +46,46 @@
   }
 )
 
-;; Store proposal details
+;; Store proposal details with weighted vote tracking
 (define-map proposals
   uint
   {
     amount: uint,
     recipient: principal,
     description: (string-ascii 100),
-    yes-votes: uint,
-    no-votes: uint,
+    yes-vote-weight: uint,
+    no-vote-weight: uint,
     executed: bool,
     start-block: uint,
-    proposer: principal
+    proposer: principal,
+    total-weight-at-creation: uint ;; Snapshot of total contributions when proposal was created
   }
 )
 
 ;; Track votes to prevent double voting
 (define-map votes
   {proposal-id: uint, voter: principal}
-  {voted: bool, support: bool}
+  {voted: bool, support: bool, weight: uint}
 )
 
 ;; =============================================================================
 ;; PRIVATE FUNCTIONS
 ;; =============================================================================
+
+;; Calculate vote weight percentage (returns percentage * 100 for precision)
+(define-private (calculate-vote-percentage (vote-weight uint) (total-weight uint))
+  (if (is-eq total-weight u0)
+    u0
+    (/ (* vote-weight u10000) total-weight) ;; Multiply by 10000 for 2 decimal precision
+  )
+)
+
+;; Check if proposal has sufficient weighted votes (51% threshold)
+(define-private (has-sufficient-weighted-votes (yes-weight uint) (total-weight uint))
+  (let ((yes-percentage (calculate-vote-percentage yes-weight total-weight)))
+    (>= yes-percentage u5100) ;; 51% * 100 for precision
+  )
+)
 
 ;; Validate proposal ID input
 (define-private (validate-proposal-id (proposal-id uint))
@@ -91,16 +108,20 @@
   (not (is-eq recipient (as-contract tx-sender)))
 )
 
-;; Check if a user is a contributor
-(define-private (is-contributor (user principal))
+;; Check if a user is a contributor and return their contribution amount
+(define-private (get-contributor-weight (user principal))
   (match (map-get? contributors user)
-    contributor-data (ok (get contributed contributor-data))
+    contributor-data 
+    (if (get contributed contributor-data)
+      (ok (get amount contributor-data))
+      (err ERR_NOT_CONTRIBUTOR)
+    )
     (err ERR_NOT_CONTRIBUTOR)
   )
 )
 
 ;; Check if proposal is still active (not expired and not executed)
-(define-private (is-proposal-active (proposal-data {amount: uint, recipient: principal, description: (string-ascii 100), yes-votes: uint, no-votes: uint, executed: bool, start-block: uint, proposer: principal}))
+(define-private (is-proposal-active (proposal-data {amount: uint, recipient: principal, description: (string-ascii 100), yes-vote-weight: uint, no-vote-weight: uint, executed: bool, start-block: uint, proposer: principal, total-weight-at-creation: uint}))
   (let (
     (executed (get executed proposal-data))
     (start (get start-block proposal-data))
@@ -125,15 +146,21 @@
     (match (map-get? contributors tx-sender)
       existing-contributor
       ;; Update existing contributor
-      (map-set contributors tx-sender {
-        contributed: true,
-        amount: (+ (get amount existing-contributor) amount)
-      })
+      (begin
+        (map-set contributors tx-sender {
+          contributed: true,
+          amount: (+ (get amount existing-contributor) amount)
+        })
+        (var-set total-contributions (+ (var-get total-contributions) amount))
+      )
       ;; New contributor
-      (map-set contributors tx-sender {
-        contributed: true,
-        amount: amount
-      })
+      (begin
+        (map-set contributors tx-sender {
+          contributed: true,
+          amount: amount
+        })
+        (var-set total-contributions (+ (var-get total-contributions) amount))
+      )
     )
     (ok amount)
   )
@@ -145,9 +172,10 @@
     ;; Validate all inputs
     (asserts! (validate-amount amount) (err ERR_INVALID_AMOUNT))
     (asserts! (validate-recipient recipient) (err ERR_INVALID_RECIPIENT))
-    (try! (is-contributor tx-sender))
+    (try! (get-contributor-weight tx-sender))
     
-    (let ((proposal-id (var-get next-proposal-id)))
+    (let ((proposal-id (var-get next-proposal-id))
+          (current-total-weight (var-get total-contributions)))
       ;; Ensure we don't overflow proposal IDs
       (asserts! (< proposal-id MAX_PROPOSAL_ID) (err ERR_INVALID_PROPOSAL_ID))
       
@@ -155,11 +183,12 @@
         amount: amount,
         recipient: recipient,
         description: description,
-        yes-votes: u0,
-        no-votes: u0,
+        yes-vote-weight: u0,
+        no-vote-weight: u0,
         executed: false,
         start-block: stacks-block-height,
-        proposer: tx-sender
+        proposer: tx-sender,
+        total-weight-at-creation: current-total-weight
       })
       (var-set next-proposal-id (+ proposal-id u1))
       (ok proposal-id)
@@ -167,41 +196,42 @@
   )
 )
 
-;; Vote on a proposal
+;; Vote on a proposal with weighted voting
 (define-public (vote (proposal-id uint) (support bool))
   (begin
     ;; Validate inputs
     (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
-    (try! (is-contributor tx-sender))
-    
-    (match (map-get? proposals proposal-id)
-      proposal-data
-      (let (
-        (vote-key {proposal-id: proposal-id, voter: tx-sender})
-      )
-        (asserts! (is-proposal-active proposal-data) (err ERR_PROPOSAL_EXPIRED))
-        (asserts! (is-none (map-get? votes vote-key)) (err ERR_ALREADY_VOTED))
-        
-        ;; Record the vote
-        (map-set votes vote-key {voted: true, support: support})
-        
-        ;; Update proposal vote counts
-        (if support
-          (map-set proposals proposal-id (merge proposal-data {
-            yes-votes: (+ (get yes-votes proposal-data) u1)
-          }))
-          (map-set proposals proposal-id (merge proposal-data {
-            no-votes: (+ (get no-votes proposal-data) u1)
-          }))
+    (let ((voter-weight (try! (get-contributor-weight tx-sender))))
+      
+      (match (map-get? proposals proposal-id)
+        proposal-data
+        (let (
+          (vote-key {proposal-id: proposal-id, voter: tx-sender})
         )
-        (ok true)
+          (asserts! (is-proposal-active proposal-data) (err ERR_PROPOSAL_EXPIRED))
+          (asserts! (is-none (map-get? votes vote-key)) (err ERR_ALREADY_VOTED))
+          
+          ;; Record the vote with weight
+          (map-set votes vote-key {voted: true, support: support, weight: voter-weight})
+          
+          ;; Update proposal vote weights
+          (if support
+            (map-set proposals proposal-id (merge proposal-data {
+              yes-vote-weight: (+ (get yes-vote-weight proposal-data) voter-weight)
+            }))
+            (map-set proposals proposal-id (merge proposal-data {
+              no-vote-weight: (+ (get no-vote-weight proposal-data) voter-weight)
+            }))
+          )
+          (ok true)
+        )
+        (err ERR_PROPOSAL_NOT_FOUND)
       )
-      (err ERR_PROPOSAL_NOT_FOUND)
     )
   )
 )
 
-;; Execute proposal if it meets threshold and requirements
+;; Execute proposal if it meets weighted threshold and requirements
 (define-public (execute-proposal (proposal-id uint))
   (begin
     ;; Validate input
@@ -213,7 +243,8 @@
         (executed (get executed proposal-data))
         (start (get start-block proposal-data))
         (expired (> (- stacks-block-height start) PROPOSAL_LIFETIME))
-        (yes-votes (get yes-votes proposal-data))
+        (yes-vote-weight (get yes-vote-weight proposal-data))
+        (total-weight (get total-weight-at-creation proposal-data))
         (proposal-amount (get amount proposal-data))
         (proposal-recipient (get recipient proposal-data))
         (balance (stx-get-balance (as-contract tx-sender)))
@@ -221,7 +252,7 @@
         ;; Validate proposal state and requirements
         (asserts! (not executed) (err ERR_PROPOSAL_ALREADY_EXECUTED))
         (asserts! (not expired) (err ERR_PROPOSAL_EXPIRED_EXEC))
-        (asserts! (>= yes-votes MIN_VOTE_THRESHOLD) (err ERR_INSUFFICIENT_VOTES))
+        (asserts! (has-sufficient-weighted-votes yes-vote-weight total-weight) (err ERR_INSUFFICIENT_VOTES))
         (asserts! (>= balance proposal-amount) (err ERR_INSUFFICIENT_BALANCE))
         
         ;; Re-validate the stored data before execution
@@ -261,6 +292,11 @@
   (stx-get-balance (as-contract tx-sender))
 )
 
+;; Get total contributions (voting weight)
+(define-read-only (get-total-contributions)
+  (var-get total-contributions)
+)
+
 ;; Check if user is a contributor
 (define-read-only (is-user-contributor (user principal))
   (match (map-get? contributors user)
@@ -283,6 +319,18 @@
   )
 )
 
+;; Get voting power percentage for a contributor
+(define-read-only (get-voting-power (user principal))
+  (match (map-get? contributors user)
+    contributor-data
+    (let ((user-weight (get amount contributor-data))
+          (total-weight (var-get total-contributions)))
+      (ok (calculate-vote-percentage user-weight total-weight))
+    )
+    (ok u0)
+  )
+)
+
 ;; Get next proposal ID
 (define-read-only (get-next-proposal-id)
   (var-get next-proposal-id)
@@ -295,6 +343,33 @@
     (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
     (match (map-get? proposals proposal-id)
       proposal-data (ok (is-proposal-active proposal-data))
+      (err ERR_PROPOSAL_NOT_FOUND)
+    )
+  )
+)
+
+;; Get proposal voting status with percentages
+(define-read-only (get-proposal-voting-status (proposal-id uint))
+  (begin
+    (asserts! (validate-proposal-id proposal-id) (err ERR_INVALID_PROPOSAL_ID))
+    (match (map-get? proposals proposal-id)
+      proposal-data
+      (let (
+        (yes-weight (get yes-vote-weight proposal-data))
+        (no-weight (get no-vote-weight proposal-data))
+        (total-weight (get total-weight-at-creation proposal-data))
+        (yes-percentage (calculate-vote-percentage yes-weight total-weight))
+        (no-percentage (calculate-vote-percentage no-weight total-weight))
+      )
+        (ok {
+          yes-weight: yes-weight,
+          no-weight: no-weight,
+          total-weight: total-weight,
+          yes-percentage: yes-percentage,
+          no-percentage: no-percentage,
+          passes-threshold: (has-sufficient-weighted-votes yes-weight total-weight)
+        })
+      )
       (err ERR_PROPOSAL_NOT_FOUND)
     )
   )

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -1,0 +1,71 @@
+---
+id: 0
+name: "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`"
+network: simnet
+genesis:
+  wallets:
+    - name: deployer
+      address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: faucet
+      address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_1
+      address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_2
+      address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_3
+      address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_4
+      address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_5
+      address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_6
+      address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_7
+      address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_8
+      address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+  contracts:
+    - genesis
+    - lockup
+    - bns
+    - cost-voting
+    - costs
+    - pox
+    - costs-2
+    - pox-2
+    - costs-3
+    - pox-3
+    - pox-4
+    - signers
+    - signers-voting
+    - costs-4
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - emulated-contract-publish:
+            contract-name: civitas
+            emulated-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            path: contracts/civitas.clar
+            clarity-version: 3
+      epoch: "3.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2060 @@
+{
+  "name": "civitas-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "civitas-tests",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@esbuild/win32-x64": "^0.25.12",
+        "@hirosystems/clarinet-sdk": "^3.0.0",
+        "@stacks/transactions": "^7.0.5",
+        "chokidar-cli": "^3.0.0",
+        "typescript": "^5.6.0",
+        "vite": "^6.1.0",
+        "vitest": "^3.0.0",
+        "vitest-environment-clarinet": "^2.3.0"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hirosystems/clarinet-sdk": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@hirosystems/clarinet-sdk/-/clarinet-sdk-3.8.1.tgz",
+      "integrity": "sha512-CFD8lLaqHI4Lht2rEkmyoHhBpLNVs0lBc5UtBrpVAglpUSCMkLNfVLSSIeBi07zpfkjJTVmJHLP36FVXr4vfMA==",
+      "deprecated": "The Clarinet SDK has been moved to @stacks/clarinet-sdk",
+      "dependencies": {
+        "@hirosystems/clarinet-sdk-wasm": "3.8.1",
+        "@stacks/transactions": "^7.0.6",
+        "kolorist": "^1.8.0",
+        "prompts": "^2.4.2",
+        "yargs": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@hirosystems/clarinet-sdk-wasm": {
+      "version": "3.8.1",
+      "license": "GPL-3.0"
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.53.3",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.53.3",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@stacks/transactions": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-7.3.0.tgz",
+      "integrity": "sha512-xtIktW0I0z+5VPnQM5ZfXpeTKKBY2XwqvhYZJdIGT5QQ3SvZpJVoP7aod2pms4IUfW53kTyCjyaNm6hFmgWOWw==",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^7.0.2",
+        "@stacks/network": "^7.2.0",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
+    "node_modules/@stacks/transactions/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@stacks/transactions/node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@stacks/transactions/node_modules/@stacks/common": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-7.0.2.tgz",
+      "integrity": "sha512-+RSecHdkxOtswmE4tDDoZlYEuULpnTQVeDIG5eZ32opK8cFxf4EugAcK9CsIsHx/Se1yTEaQ21WGATmJGK84lQ=="
+    },
+    "node_modules/@stacks/transactions/node_modules/@stacks/network": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-7.2.0.tgz",
+      "integrity": "sha512-AkLougCF2RLbK97TtISZxAhF3cE757XMXWOGKvEFWNauiQ5/bYyI9W5jZypG3yI/AyYIo04NKoFWWTnpJcn1iA==",
+      "dependencies": {
+        "@stacks/common": "^7.0.2",
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@stacks/transactions/node_modules/c32check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
+      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "base-x": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stacks/transactions/node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/base-x": {
+      "version": "4.0.1",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chai/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar-cli": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "lodash.debounce": "^4.0.8",
+        "lodash.throttle": "^4.1.1",
+        "yargs": "^13.3.0"
+      },
+      "bin": {
+        "chokidar": "index.js"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/cliui": {
+      "version": "5.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "license": "MIT"
+    },
+    "node_modules/chokidar-cli/node_modules/string-width": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/y18n": {
+      "version": "4.0.3",
+      "license": "ISC"
+    },
+    "node_modules/chokidar-cli/node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/chokidar-cli/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "license": "MIT"
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magic-string/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/postcss/node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/rollup": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest-environment-clarinet": {
+      "version": "2.6.0",
+      "license": "GPL-3.0",
+      "peerDependencies": {
+        "@hirosystems/clarinet-sdk": ">=2.14.0",
+        "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "license": "ISC"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "civitas-tests",
   "version": "1.0.0",
@@ -13,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@esbuild/win32-x64": "^0.25.12",
     "@hirosystems/clarinet-sdk": "^3.0.0",
     "@stacks/transactions": "^7.0.5",
     "chokidar-cli": "^3.0.0",

--- a/tests/civitas.test.ts
+++ b/tests/civitas.test.ts
@@ -1,21 +1,208 @@
 
 import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
 
+const contractName = "civitas";
 const accounts = simnet.getAccounts();
-const address1 = accounts.get("wallet_1")!;
+const deployer = accounts.get("deployer")!;
+const wallet1 = accounts.get("wallet_1")!;
+const wallet2 = accounts.get("wallet_2")!;
+const wallet3 = accounts.get("wallet_3")!;
 
-/*
-  The test below is an example. To learn more, read the testing documentation here:
-  https://docs.hiro.so/stacks/clarinet-js-sdk
-*/
+const MIN_CONTRIBUTION = 1_000_000n;
+const PROPOSAL_LIFETIME = 100n;
+const ERR_INVALID_AMOUNT = 400n;
+const ERR_NOT_CONTRIBUTOR = 300n;
+const ERR_ALREADY_VOTED = 101n;
+const ERR_WEIGHT_AFTER_SNAPSHOT = 403n;
+const ERR_INSUFFICIENT_VOTES = 201n;
+const ERR_PROPOSAL_EXPIRED = 104n;
+const ERR_PROPOSAL_EXPIRED_EXEC = 204n;
 
-describe("example tests", () => {
-  it("ensures simnet is well initialised", () => {
-    expect(simnet.blockHeight).toBeDefined();
+const contribute = (sender: string, amount: bigint) =>
+  simnet.callPublicFn(contractName, "contribute", [Cl.uint(amount)], sender);
+
+const propose = (sender: string, amount: bigint, recipient: string, description: string) =>
+  simnet.callPublicFn(contractName, "propose-spend", [
+    Cl.uint(amount),
+    Cl.standardPrincipal(recipient),
+    Cl.stringAscii(description),
+  ], sender);
+
+const vote = (sender: string, proposalId: bigint, support: boolean) =>
+  simnet.callPublicFn(contractName, "vote", [Cl.uint(proposalId), Cl.bool(support)], sender);
+
+describe("contribute", () => {
+  it("accepts valid contributions and rejects amounts below the minimum", () => {
+    const ok = contribute(wallet1, MIN_CONTRIBUTION);
+    expect(ok.result).toBeOk(Cl.uint(MIN_CONTRIBUTION));
+
+    const total = simnet.callReadOnlyFn(contractName, "get-total-contributions", [], wallet1);
+    expect(total.result).toBeUint(MIN_CONTRIBUTION);
+
+    const contributor = simnet.callReadOnlyFn(
+      contractName,
+      "get-contributor",
+      [Cl.standardPrincipal(wallet1)],
+      deployer,
+    );
+    expect(contributor.result).toBeSome(
+      Cl.tuple({
+        contributed: Cl.bool(true),
+        amount: Cl.uint(MIN_CONTRIBUTION),
+        "last-contribution-proposal-id": Cl.uint(0),
+      }),
+    );
+
+    const tooSmall = contribute(wallet2, MIN_CONTRIBUTION - 1n);
+    expect(tooSmall.result).toBeErr(Cl.uint(ERR_INVALID_AMOUNT));
+  });
+});
+
+describe("propose-spend", () => {
+  it("requires contributors and snapshots the total weight at creation", () => {
+    contribute(wallet1, 2_000_000n);
+    contribute(wallet2, 1_000_000n);
+
+    const nonContributor = propose(wallet3, 500_000n, wallet2, "should fail");
+    expect(nonContributor.result).toBeErr(Cl.uint(ERR_NOT_CONTRIBUTOR));
+
+    const proposal = propose(wallet1, 500_000n, wallet2, "fund wallet2");
+    expect(proposal.result).toBeOk(Cl.uint(0));
+
+    const status = simnet.callReadOnlyFn(
+      contractName,
+      "get-proposal-voting-status",
+      [Cl.uint(0)],
+      deployer,
+    );
+    expect(status.result).toBeOk(
+      Cl.tuple({
+        "yes-weight": Cl.uint(0),
+        "no-weight": Cl.uint(0),
+        "total-weight": Cl.uint(3_000_000n),
+        "yes-percentage": Cl.uint(0),
+        "no-percentage": Cl.uint(0),
+        "passes-threshold": Cl.bool(false),
+      }),
+    );
+
+    const nextId = simnet.callReadOnlyFn(contractName, "get-next-proposal-id", [], deployer);
+    expect(nextId.result).toBeUint(1);
+  });
+});
+
+describe("vote", () => {
+  it("tracks weighted votes, blocks double-voting, and rejects post-snapshot weight", () => {
+    contribute(wallet1, 2_000_000n);
+    contribute(wallet2, 1_000_000n);
+    propose(wallet1, 1_000_000n, wallet2, "operating budget");
+
+    const yesVote = vote(wallet1, 0n, true);
+    expect(yesVote.result).toBeOk(Cl.bool(true));
+
+    const doubleVote = vote(wallet1, 0n, false);
+    expect(doubleVote.result).toBeErr(Cl.uint(ERR_ALREADY_VOTED));
+
+    contribute(wallet3, MIN_CONTRIBUTION);
+    const lateWeight = vote(wallet3, 0n, true);
+    expect(lateWeight.result).toBeErr(Cl.uint(ERR_WEIGHT_AFTER_SNAPSHOT));
+
+    const noVote = vote(wallet2, 0n, false);
+    expect(noVote.result).toBeOk(Cl.bool(true));
+
+    const status = simnet.callReadOnlyFn(
+      contractName,
+      "get-proposal-voting-status",
+      [Cl.uint(0)],
+      deployer,
+    );
+    expect(status.result).toBeOk(
+      Cl.tuple({
+        "yes-weight": Cl.uint(2_000_000n),
+        "no-weight": Cl.uint(1_000_000n),
+        "total-weight": Cl.uint(3_000_000n),
+        "yes-percentage": Cl.uint(6666),
+        "no-percentage": Cl.uint(3333),
+        "passes-threshold": Cl.bool(true),
+      }),
+    );
+  });
+});
+
+describe("execute-proposal", () => {
+  it("executes when threshold met and updates treasury and contributor weight", () => {
+    contribute(wallet1, 2_000_000n);
+    contribute(wallet2, 1_000_000n);
+    propose(wallet1, 1_000_000n, wallet2, "payout");
+    vote(wallet1, 0n, true);
+    vote(wallet2, 0n, true);
+
+    const exec = simnet.callPublicFn(contractName, "execute-proposal", [Cl.uint(0)], wallet1);
+    expect(exec.result).toBeOk(Cl.bool(true));
+
+    const balance = simnet.callReadOnlyFn(contractName, "get-balance", [], deployer);
+    expect(balance.result).toBeUint(2_000_000n);
+
+    const totalWeight = simnet.callReadOnlyFn(
+      contractName,
+      "get-total-contributions",
+      [],
+      deployer,
+    );
+    expect(totalWeight.result).toBeUint(2_000_000n);
+
+    const recipient = simnet.callReadOnlyFn(
+      contractName,
+      "get-contributor",
+      [Cl.standardPrincipal(wallet2)],
+      deployer,
+    );
+    expect(recipient.result).toBeSome(
+      Cl.tuple({
+        contributed: Cl.bool(false),
+        amount: Cl.uint(0),
+        "last-contribution-proposal-id": Cl.uint(0),
+      }),
+    );
+
+    const active = simnet.callReadOnlyFn(
+      contractName,
+      "is-proposal-active-check",
+      [Cl.uint(0)],
+      deployer,
+    );
+    expect(active.result).toBeOk(Cl.bool(false));
   });
 
-  // it("shows an example", () => {
-  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
-  //   expect(result).toBeUint(0);
-  // });
+  it("fails to execute when votes are below the 51% threshold", () => {
+    contribute(wallet1, 1_000_000n);
+    contribute(wallet2, 1_000_000n);
+    propose(wallet1, 500_000n, wallet2, "needs more votes");
+    vote(wallet1, 0n, true);
+
+    const exec = simnet.callPublicFn(contractName, "execute-proposal", [Cl.uint(0)], wallet1);
+    expect(exec.result).toBeErr(Cl.uint(ERR_INSUFFICIENT_VOTES));
+  });
+
+  it("prevents voting and execution after expiry", () => {
+    contribute(wallet1, 1_000_000n);
+    propose(wallet1, 500_000n, wallet2, "expires");
+
+    simnet.mineEmptyStacksBlocks(Number(PROPOSAL_LIFETIME + 1n));
+
+    const expiredVote = vote(wallet1, 0n, true);
+    expect(expiredVote.result).toBeErr(Cl.uint(ERR_PROPOSAL_EXPIRED));
+
+    const exec = simnet.callPublicFn(contractName, "execute-proposal", [Cl.uint(0)], wallet1);
+    expect(exec.result).toBeErr(Cl.uint(ERR_PROPOSAL_EXPIRED_EXEC));
+
+    const active = simnet.callReadOnlyFn(
+      contractName,
+      "is-proposal-active-check",
+      [Cl.uint(0)],
+      deployer,
+    );
+    expect(active.result).toBeOk(Cl.bool(false));
+  });
 });


### PR DESCRIPTION


This PR introduces a minimal DAO treasury contract implemented in Clarity to accept contributions in STX, create spending proposals, vote, and execute approved transfers.

## File added/modified
- contracts/civitas.clar

## Overview
- Contributors deposit STX to the contract.
- Contributors can propose spending requests, vote once per proposal, and execute proposals that meet a fixed yes-vote threshold before expiry.
- Funds are transferred from the contract to a specified recipient upon successful execution.

## Constants and constraints
- MIN_VOTE_THRESHOLD: u2 (yes votes needed to execute)
- PROPOSAL_LIFETIME: u100 blocks (proposal expiry window)
- MIN_CONTRIBUTION: u1000000 (1 STX minimum)
- MAX_PROPOSAL_AMOUNT: u1000000000000 (cap for contributions and proposal amounts)
- MAX_PROPOSAL_ID: u4294967295 (uint32 cap)

## State
- Data var:
  - next-proposal-id: uint (starts at u0)
- Maps:
  - contributors: principal -> { contributed: bool, amount: uint }
  - proposals: uint -> { amount, recipient, description (string-ascii 100), yes-votes, no-votes, executed, start-block, proposer }
  - votes: {proposal-id: uint, voter: principal} -> { voted: bool, support: bool }

## Public functions
- contribute(amount uint) -> (response uint uint)
  - Requires amount >= MIN_CONTRIBUTION and <= MAX_PROPOSAL_AMOUNT; transfers STX to the contract and upserts contributor record.
- propose-spend(amount uint, recipient principal, description (string-ascii 100)) -> (response uint uint)
  - Caller must be a contributor; validates amount/recipient; stores proposal at next-proposal-id and increments it.
- vote(proposal-id uint, support bool) -> (response bool uint)
  - Caller must be a contributor; active proposal only; prevents double-voting; increments yes/no counters.
- execute-proposal(proposal-id uint) -> (response bool uint)
  - Requires active, not-executed proposal with yes-votes >= MIN_VOTE_THRESHOLD and sufficient contract balance; transfers STX from contract to recipient and marks executed.

## Read-only functions
- get-proposal(proposal-id) -> (response {…} uint)
- get-balance() -> uint
- is-user-contributor(user) -> (response bool none)
- get-contributor(user) -> (optional {…})
- get-vote(proposal-id, voter) -> (response (optional {…}) uint)
- get-next-proposal-id() -> uint
- is-proposal-active-check(proposal-id) -> (response bool uint)

## Validation and helpers (private)
- validate-proposal-id, validate-amount, validate-recipient
- is-contributor (response)
- is-proposal-active (based on executed=false and (stacks-block-height - start-block) > PROPOSAL_LIFETIME being false)

## Notable behavior
- One-address-one-vote; votes are not weighted by contribution.
- Execution threshold depends only on yes-votes (no quorum/majority calculation).
- Proposals expire when (stacks-block-height - start-block) > PROPOSAL_LIFETIME.
- Recipient cannot be the contract principal.
- No withdrawal function for contributors.

## Error codes
ERR_NOT_CONTRIBUTOR, ERR_ALREADY_VOTED, ERR_PROPOSAL_NOT_FOUND, ERR_PROPOSAL_EXECUTED, ERR_PROPOSAL_EXPIRED, ERR_INSUFFICIENT_VOTES, ERR_INSUFFICIENT_BALANCE, ERR_PROPOSAL_ALREADY_EXECUTED, ERR_PROPOSAL_EXPIRED_EXEC, ERR_PROPOSAL_NOT_FOUND_EXEC, ERR_INVALID_AMOUNT, ERR_INVALID_PROPOSAL_ID, ERR_INVALID_RECIPIENT.

## Basic usage flow
1) contribute(amount >= 1 STX)
2) propose-spend(amount, recipient, description)
3) vote(proposal-id, support)
4) execute-proposal(proposal-id) after threshold met and before expiry